### PR TITLE
Test workaround for one-at-a-time annotation viewing.

### DIFF
--- a/sites/all/modules/annotationViewer/assets/js/view_annotator.js
+++ b/sites/all/modules/annotationViewer/assets/js/view_annotator.js
@@ -422,6 +422,8 @@ Drupal.behaviors.AnnotationViewer = {
 						// Clear selection indicator
 						jQuery(".annotator-marginviewer-element").removeClass("annotation_selected");
 
+						// TODO: Test this idea for one-at-a-time viewing
+						jQuery(".annotator-marginviewer-element").hide(); // Hide all annotations
 
 						if(scrollToVal != 0){
 							// FIXME: this should work, but it doesn't, so we just go to 0 first and then offset
@@ -435,6 +437,9 @@ Drupal.behaviors.AnnotationViewer = {
 								jQuery(".annotator-marginviewer-element").removeClass("annotation_selected");
 							});
 						}
+
+						jQuery(targetDiv).show(); // Show this annotation
+
 						complete();
 					}
 

--- a/sites/all/modules/annotationViewer/assets/js/view_annotator.js
+++ b/sites/all/modules/annotationViewer/assets/js/view_annotator.js
@@ -422,9 +422,6 @@ Drupal.behaviors.AnnotationViewer = {
 						// Clear selection indicator
 						jQuery(".annotator-marginviewer-element").removeClass("annotation_selected");
 
-						// TODO: Test this idea for one-at-a-time viewing
-						jQuery(".annotator-marginviewer-element").hide(); // Hide all annotations
-
 						if(scrollToVal != 0){
 							// FIXME: this should work, but it doesn't, so we just go to 0 first and then offset
 							//console.log("Scrolling: "+scrollToVal + "(current:"+currentPosition+")");
@@ -438,6 +435,8 @@ Drupal.behaviors.AnnotationViewer = {
 							});
 						}
 
+						// TODO: Test this idea for one-at-a-time viewing
+						jQuery(".annotator-marginviewer-element").hide(); // Hide all annotations
 						jQuery(targetDiv).show(); // Show this annotation
 
 						complete();


### PR DESCRIPTION
- Hide all annotations.
- Once scrolling is complete, show the selected one.